### PR TITLE
修改189脚本，去掉打印隐私信息...脑袋犯抽了

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ python脚本集，有原创的，也有站在巨人的肩膀上做的修改版�
 2. [HostLoc赚积分【基于SeleniumBase】](<https://github.com/Arronlong/py_scripts/tree/master/scripts/hostloc>)（[模拟登陆](https://github.com/Arronlong/py_scripts/blob/master/scripts/hostloc/README_py_login.md)和[基于cookie](https://github.com/Arronlong/py_scripts/blob/master/scripts/hostloc/README_py_cookie.md)的脚本均已失效）
 3. [天翼云盘签到+抽奖](<https://github.com/Arronlong/py_scripts/tree/master/scripts/C189>)
 4. [EUserv续订](<https://github.com/Arronlong/py_scripts/tree/master/scripts/euserv>)
-5. [自动更新DNS的三大路线的解析为CF优质IP](<https://github.com/Arronlong/py_scripts/tree/master/scripts/cf2dns>)
+5. [自动更新DNS智能解析为CF优质IP](<https://github.com/Arronlong/py_scripts/tree/master/scripts/cf2dns>)
 
 功能对应的参数，请点击后自行查看。
 

--- a/scripts/_C189.sh
+++ b/scripts/_C189.sh
@@ -6,12 +6,10 @@ pwd_list=()
 IFS=","
 for u in ${user[*]}
 do
-  echo ${u}
   user_list[${#user_list[*]}]=${u}
 done
 for p in ${pwd[*]}
 do
-  echo ${p}
   pwd_list[${#pwd_list[*]}]=${p}
 done
 


### PR DESCRIPTION
老兄，189的脚本在测试时打印了用户名和密码，对于多个账号会暴露出来，所以赶紧给你推送了一个更新，或者你手动把scripts/_C189.sh 的第14行、第9行的删掉即可。为了防止用户名密码泄露，最好更改一下密码，实在不好意思